### PR TITLE
The --username flag in grr_config_updater has been removed

### DIFF
--- a/admin.adoc
+++ b/admin.adoc
@@ -56,7 +56,7 @@ possible to use the config_updater.py script:
 To add the user joe as an admin:
 [source,shell]
 --------------------------------------------------------------------------------
-db@host:~$ sudo grr_config_updater add_user --username joe
+db@host:~$ sudo grr_config_updater add_user joe
 Using configuration <ConfigFileParser filename="/etc/grr/grr-server.conf">
 Please enter password for user 'joe':
 Updating user joe


### PR DESCRIPTION
It appears that --username is no longer a flag in **grr_config_updater**: 

```
sudo grr_config_updater add_user --username XXXXXX
usage: grr_config_updater [-h] [--verbose] [--debug] [--config CONFIG]
                          [--secondary_configs SECONDARY_CONFIGS]
                          [--config_help] [--context CONTEXT]
                          [--plugins PLUGINS] [-p PARAMETER] [--list_storage]
                          [--share_dir SHARE_DIR]

                          {load_memory_drivers,generate_keys,repack_clients,initialize,update_user,add_user,delete_user,show_user,upload_raw,upload_artifact,upload_python,upload_exe,upload_memory_driver}
                          ...
grr_config_updater: error: unrecognized arguments: --username
```

Omitting the flag works just fine: 

```
sudo grr_config_updater add_user XXXXX
```
