### PR TITLE
Move installation file to github.

### DIFF
--- a/quickstart.adoc
+++ b/quickstart.adoc
@@ -17,7 +17,7 @@ This document describes getting a server and clients up and running for the firs
 Download the installation script e.g. using wget:
 
 ---------------------------------------------------------------------------------------
-wget https://googledrive.com/host/0B1wsLqFoT7i2c3F0ZmI1RDJlUEU/install_script_ubuntu.sh
+wget https://github.com/google/grr/blob/master/install_script_ubuntu.sh
 ---------------------------------------------------------------------------------------
 
 If you don't have wget you can install it by running:

--- a/quickstart.adoc
+++ b/quickstart.adoc
@@ -20,12 +20,6 @@ Download the installation script e.g. using wget:
 wget https://github.com/google/grr/blob/master/install_script_ubuntu.sh
 ---------------------------------------------------------------------------------------
 
-If you don't have wget you can install it by running:
-
--------------------------------------------------------
-sudo apt-get install wget
--------------------------------------------------------
-
 Run the installation script:
 
 -------------------------------------------------------

--- a/quickstart.adoc
+++ b/quickstart.adoc
@@ -17,7 +17,7 @@ This document describes getting a server and clients up and running for the firs
 Download the installation script e.g. using wget:
 
 ---------------------------------------------------------------------------------------
-wget https://github.com/google/grr/blob/master/install_script_ubuntu.sh
+wget https://raw.githubusercontent.com/google/grr/master/scripts/install_script_ubuntu.sh
 ---------------------------------------------------------------------------------------
 
 Run the installation script:


### PR DESCRIPTION
The installation script used to be hosted on Google Drive. This has problems:

1. The URL is not authenticating. Even though it is HTTPS, anyone can host 
   things on Google Drive. While users can rely on us providing a link via
   HTTPS-served documentation on a different domain, the URL of the script
   would be nice to be self-evidently authentiating.

2. The URL is not human-recognizable or memorable.

3. It's difficult to update the Google Drive file. For example, I don't know
   how to go about it currently. But everyone knows how to open a GitHub pull
   request.

4. The file is not versioned, with all that this entails. We can't blame or
   find when a feature was introduced.

This patch moves the installation file to GitHub.

Depends https://github.com/google/grr/pull/101