### PR TITLE
Added recommendation to use vagrant-vbguest

### DIFF
--- a/admin.adoc
+++ b/admin.adoc
@@ -547,7 +547,7 @@ You'll need a copy of the GRR source:
 > git clone https://github.com/google/grr.git
 --------------------------------------------------------------------------------
 
-and the latest versions of link:https://www.vagrantup.com/[Vagrant] and VirtualBox installed.
+and the latest versions of link:https://www.vagrantup.com/[Vagrant] and VirtualBox installed. The Linux VM's provided by the project were built with an older version of VirtualBox. It is recommended that you install the plugin link:https://github.com/dotless-de/vagrant-vbguest[vagrant-vbguest] to update the guest additions to the current version your running on the build host.
 
 OS X and windows require some extra work, see here for instructions:
 


### PR DESCRIPTION
Added recommendation to use vagrant-vbguest in order to keep the virtualbox guest additions up to date with the current version of vritualbox on the build host.