### PR TITLE
Install explicit protoc version

### DIFF
--- a/installfrompip.adoc
+++ b/installfrompip.adoc
@@ -71,12 +71,16 @@ sudo apt-get install -y \
   libffi-dev \
   libssl-dev \
   prelink \
-  protobuf-compiler \
   python-dev \
   python-pip \
   rpm \
   wget \
   zip
+
+cd /usr/local && \
+  wget --quiet "https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip" && \
+  unzip -q protoc-3.3.0-linux-x86_64.zip -x readme.txt && \
+  rm protoc-3.3.0-linux-x86_64.zip
 
 sudo pip install --upgrade pip
 sudo pip install virtualenv


### PR DESCRIPTION
This is ugly but v3.3.0 is explicitly required (see grr/makefile.py,
grr/Dockerfile) and latest available in any current Ubuntu release is
3.0.0 (zesty).