### PR TITLE
./setup.py was moved to ./grr/core

### DIFF
--- a/developing-grr/setting-up-dev-env.md
+++ b/developing-grr/setting-up-dev-env.md
@@ -103,7 +103,7 @@ following commands:
 ```bash
 pip install -e ./grr/proto
 pip install -e ./api_client/python
-pip install -e .
+pip install -e ./grr/core
 pip install -e ./grr/client
 pip install -e ./grr/server/[mysqldatastore]
 pip install -e ./grr/test


### PR DESCRIPTION
From branch 3.2.4.4, ./setup.py was moved in ./grr/core/