### PR TITLE
Update from-source.md

### DIFF
--- a/installing-grr-server/from-source.md
+++ b/installing-grr-server/from-source.md
@@ -9,7 +9,7 @@ First, install the prerequisites:
 ```bash
 sudo apt install -y fakeroot debhelper libffi-dev libssl-dev python-dev \
   python-pip wget openjdk-8-jdk zip git devscripts dh-systemd dh-virtualenv \
-  libc6-i386 lib32z1 asciidoc
+  libc6-i386 lib32z1 asciidoc libmysqlclient-dev
 ```
 
 * Centos:


### PR DESCRIPTION
[-] libmysqlclient-dev is a necessary library on Ubuntu 18.04, and is not included as part of the mysql-server package from apt