### PR TITLE
Workaround for "mysql does not start with overlay2"

### DIFF
--- a/installing-grr-server/via-docker.md
+++ b/installing-grr-server/via-docker.md
@@ -17,6 +17,7 @@ docker run \
   --name grr-server \
   -e EXTERNAL_HOSTNAME="localhost" \
   -e ADMIN_PASSWORD="demo" \
+  -v /var/lib/mysql \
   -p 0.0.0.0:8000:8000 -p 0.0.0.0:8080:8080 \
   grrdocker/grr:v__GRR_VERSION__
 ```


### PR DESCRIPTION
Affects docker for mac, container fails to start when starting mysql. Issue is known, suggested workaround is to mount a volume for /var/lib/mysql.

See: https://github.com/docker/for-linux/issues/72

This merge request suggests a solution by modifying the documentation. Another workaround as pointed out in the issue above, which is somewhat more intrusive since it must be implemented in the Dockerfile:
```RUN find /var/lib/mysql -type f -exec touch {} \;```