### PR TITLE
Update file-organization.md

### DIFF
--- a/maintaining-and-tuning/configuration/file-organization.md
+++ b/maintaining-and-tuning/configuration/file-organization.md
@@ -2,7 +2,7 @@
 
 When GRR is installed on a system, a system wide, distribution specific, configuration file is also installed (by default `/etc/grr/grr_server.yaml`). This specifies the basic configuration of the GRR service (i.e. various distribution specific locations). However, the configuration typically needs to be updated with site specific parameters (for example new crypto keys, the `Client.control_urls` setting to allow the client to connect to the server, etc.)
 
-In order to avoid overwriting the user customized configuration files when GRR is updated in future, we write site specific configuration files to a location specified by the `Config.writeback` config option (by default `/etc/grr/grr.local.yaml`). This local file only contains the parameters which are changed from the defaults, or the system configuration file.
+In order to avoid overwriting the user customized configuration files when GRR is updated in future, we write site specific configuration files to a location specified by the `Config.writeback` config option (by default `/etc/grr/server.local.yaml`). This local file only contains the parameters which are changed from the defaults, or the system configuration file.
 
 > **Note**
 >


### PR DESCRIPTION
I've noticed that in my new GRR instalation (v3.4.0.1) default writeback file was /etc/grr/server.local.yaml.