### PR TITLE
Minor fix: Update python-devel name for Buster and CentOS 8

### DIFF
--- a/installing-grr-server/from-released-pip.md
+++ b/installing-grr-server/from-released-pip.md
@@ -16,13 +16,13 @@ First, install the prerequisites:
 * Ubuntu:
 
 ```bash
-apt install -y debhelper dpkg-dev python-dev python-pip rpm zip
+apt install -y debhelper dpkg-dev python3-dev python-pip rpm zip
 ```
 
 * Centos:
 
 ```bash
-yum install -y epel-release python-devel wget which libffi-devel \
+yum install -y epel-release python3-devel wget which libffi-devel \
   openssl-devel zip git gcc gcc-c++ redhat-rpm-config
 
 yum install -y python-pip


### PR DESCRIPTION
Changing to python3-dev on apt-based systems (see also: ad4b1be1b0f08b8260697b1b625a949442c2b02b) and python3-devel for CentOS (>= 8) when installing from the released pip packages.